### PR TITLE
Bump faraday gem to v1

### DIFF
--- a/fx_street.gemspec
+++ b/fx_street.gemspec
@@ -21,7 +21,10 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
 
-  spec.add_dependency "faraday", "~> 0.9.0"
-  spec.add_dependency "faraday_middleware", "~> 0.9.0"
-  spec.add_dependency "rash", "~> 0.4.0"
+  spec.add_dependency "faraday", "~> 1.0.0"
+  spec.add_dependency "faraday_middleware", "~> 1.0.0"
+  # Replace rash gem with the rash_alt gem
+  # https://github.com/lostisland/faraday_middleware/tree/243239feedb9713ff89479c4b6535ea709d014fa
+  # https://github.com/lostisland/faraday_middleware/pull/136
+  spec.add_dependency "rash_alt", "~> 0.4.12"
 end

--- a/lib/fx_street/version.rb
+++ b/lib/fx_street/version.rb
@@ -1,3 +1,3 @@
 module FXStreet
-  VERSION = "0.0.3"
+  VERSION = "0.0.4"
 end


### PR DESCRIPTION
- Bump `faraday` gem to v1
- Bump `faraday_middleware` gem to v1
- Replace `rash` gem with `rash_alt` gem to fix the error `RuntimeError (missing dependency for FaradayMiddleware::Rashify: uninitialized constant Hashie::Mash::Rash)` once `faraday_middleware` gem is bumped to v1.